### PR TITLE
Adjust SPI frequency

### DIFF
--- a/common/src/animations.rs
+++ b/common/src/animations.rs
@@ -627,20 +627,20 @@ pub fn initialize_animations<'a>(
     let uni_color_sparkle = UniColorSparkle::new(led_data, prng.random());
 
     [
+        Animation::MultiColorStrand(multi_color_strand),
         Animation::Carrousel(carrousel),
         Animation::DoubleCarrousel(double_carrousel),
+        Animation::UniColorSparkle(uni_color_sparkle),
+        Animation::MultiColorSparkle(multi_color_sparkle),
         Animation::ForwardWave(forward_wave),
+        Animation::UniColorFadeIn(uni_color_fade_in),
         Animation::MultiColorFadeIn(multi_color_fade_in),
-        Animation::MultiColorHeartbeat(multi_color_heartbeat),
+        Animation::UniColorFrontToBackWave(uni_color_front_to_back_wave),
         Animation::MultiColorSolid(multi_color_solid),
         Animation::MultiColorSolidRandom(multi_color_solid_random),
-        Animation::MultiColorSparkle(multi_color_sparkle),
-        Animation::MultiColorStrand(multi_color_strand),
-        Animation::UniColorFadeIn(uni_color_fade_in),
-        Animation::UniColorFrontToBackWave(uni_color_front_to_back_wave),
-        Animation::UniColorHeartbeat(uni_color_heartbeat),
         Animation::UniColorSolid(uni_color_solid),
-        Animation::UniColorSparkle(uni_color_sparkle),
+        Animation::UniColorHeartbeat(uni_color_heartbeat),
+        Animation::MultiColorHeartbeat(multi_color_heartbeat),
     ]
 }
 

--- a/quinled_dig_quad/.cargo/config.toml
+++ b/quinled_dig_quad/.cargo/config.toml
@@ -8,7 +8,7 @@ rustflags = [
 target = "xtensa-esp32-none-elf"
 
 [env]
-DEFMT_LOG="debug"
+DEFMT_LOG="info"
 
 [unstable]
 build-std = ["core"]

--- a/quinled_dig_quad/src/led.rs
+++ b/quinled_dig_quad/src/led.rs
@@ -23,7 +23,8 @@ pub async fn led_task(
     info!("Starting LED task...");
 
     // According to the ws2812_spi documentation, the SPI frequency must be between 2 and 3.8 MHz.
-    let spi = Spi::new(spi, SpiConfig::default().with_frequency(Rate::from_mhz(2)))
+    // Though, in practice, it seems to have a lower limit of around 2.2 MHz.
+    let spi = Spi::new(spi, SpiConfig::default().with_frequency(Rate::from_khz(2_200)))
         .unwrap()
         .with_mosi(led)
         .into_async();

--- a/quinled_dig_quad/src/led.rs
+++ b/quinled_dig_quad/src/led.rs
@@ -24,10 +24,13 @@ pub async fn led_task(
 
     // According to the ws2812_spi documentation, the SPI frequency must be between 2 and 3.8 MHz.
     // Though, in practice, it seems to have a lower limit of around 2.2 MHz.
-    let spi = Spi::new(spi, SpiConfig::default().with_frequency(Rate::from_khz(2_200)))
-        .unwrap()
-        .with_mosi(led)
-        .into_async();
+    let spi = Spi::new(
+        spi,
+        SpiConfig::default().with_frequency(Rate::from_khz(2_200)),
+    )
+    .unwrap()
+    .with_mosi(led)
+    .into_async();
 
     let mut ws2812 = Ws2812::new(spi);
     let mut delay = Delay;


### PR DESCRIPTION
The documented 2 Mhz seems to be too low and result in the wrong colors to be displayed.