### PR TITLE
Use ws2812-spi prerendered module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "rand",
  "smart-leds",
  "smart-leds-trait",
+ "ws2812-spi",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,3 +15,4 @@ embedded-hal-async = { workspace = true }
 rand = { workspace = true }
 smart-leds = { workspace = true }
 smart-leds-trait = { workspace = true }
+ws2812-spi = { workspace = true }

--- a/common/src/animations/multi_color_heartbeat.rs
+++ b/common/src/animations/multi_color_heartbeat.rs
@@ -4,7 +4,7 @@ use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use smart_leds::RGB8;
+use smart_leds::{RGB8, gamma};
 use smart_leds_trait::SmartLedsWrite;
 
 const STEP: u8 = 10;
@@ -29,11 +29,23 @@ impl<'a> MultiColorHeartbeat<'a> {
         }
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
         delay: &mut impl DelayNs, settings: &Settings,
-    ) {
-        ws2812.write(self.data.borrow().iter().copied()).unwrap();
+    ) where
+        E: SpiError,
+    {
+        let brightness = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+
+        ws2812
+            .write(smart_leds::brightness(
+                gamma(self.data.borrow().iter().copied()),
+                brightness,
+            ))
+            .unwrap();
+
         match self.sequence {
             3 => delay.delay_ms(settings.delay() * 25).await,
             _ => delay.delay_ms(settings.delay()).await,
@@ -46,12 +58,9 @@ impl<'a> MultiColorHeartbeat<'a> {
         self.sequence = 0;
     }
 
-    pub(crate) fn update(&mut self, settings: &Settings) {
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color = animations::create_color_with_brightness(COLORS[self.color_index], brightness);
+    pub(crate) fn update(&mut self) {
         for i in 0..NUM_LEDS {
-            self.data.borrow_mut()[i] = color;
+            self.data.borrow_mut()[i] = COLORS[self.color_index];
         }
 
         match self.sequence {
@@ -84,7 +93,7 @@ impl<'a> MultiColorHeartbeat<'a> {
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 }

--- a/common/src/animations/multi_color_solid.rs
+++ b/common/src/animations/multi_color_solid.rs
@@ -1,8 +1,8 @@
 use crate::animations;
-use crate::animations::{LedData, NUM_COLORS, NUM_LEDS, Settings};
+use crate::animations::{COLORS, LedData, NUM_COLORS, NUM_LEDS, Settings};
 use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
-use smart_leds::RGB8;
+use smart_leds::{RGB8, brightness, gamma};
 use smart_leds_trait::SmartLedsWrite;
 
 const LEDS_PER_COLOR: usize = NUM_LEDS / NUM_COLORS;
@@ -16,11 +16,19 @@ impl<'a> MultiColorSolid<'a> {
         Self { data }
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
-        delay: &mut impl DelayNs,
-    ) {
-        ws2812.write(self.data.borrow().iter().copied()).unwrap();
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
+        delay: &mut impl DelayNs, settings: &Settings,
+    ) where
+        E: SpiError,
+    {
+        ws2812
+            .write(brightness(
+                gamma(self.data.borrow().iter().copied()),
+                self.brightness(settings),
+            ))
+            .unwrap();
         // Delay from the settings doesn't really matter for the solid animations. So just using a
         // 1-second delay.
         delay.delay_ms(1_000u32).await;
@@ -30,21 +38,18 @@ impl<'a> MultiColorSolid<'a> {
         animations::reset_data(self.data);
     }
 
-    pub(crate) fn update(&mut self, settings: &Settings) {
+    pub(crate) fn update(&mut self) {
         let mut color_index = 0;
 
         for i in 0..NUM_LEDS {
             if i % LEDS_PER_COLOR == 0 {
                 color_index += 1;
             }
-            self.data.borrow_mut()[i] = animations::create_color_with_brightness(
-                animations::COLORS[color_index % NUM_COLORS],
-                self.brightness(settings),
-            );
+            self.data.borrow_mut()[i] = COLORS[color_index % NUM_COLORS];
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 }

--- a/common/src/animations/multi_color_solid_random.rs
+++ b/common/src/animations/multi_color_solid_random.rs
@@ -4,7 +4,7 @@ use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use smart_leds::RGB8;
+use smart_leds::{RGB8, brightness, gamma};
 use smart_leds_trait::SmartLedsWrite;
 
 pub struct MultiColorSolidRandom<'a> {
@@ -33,11 +33,20 @@ impl<'a> MultiColorSolidRandom<'a> {
         animation
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
-        delay: &mut impl DelayNs,
-    ) {
-        ws2812.write(self.data.borrow().iter().copied()).unwrap();
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
+        delay: &mut impl DelayNs, settings: &Settings,
+    ) where
+        E: SpiError,
+    {
+        ws2812
+            .write(brightness(
+                gamma(self.data.borrow().iter().copied()),
+                self.brightness(settings),
+            ))
+            .unwrap();
+
         // Delay from the settings doesn't really matter for the solid animations. So just using a
         // 1-second delay.
         delay.delay_ms(1_000u32).await;
@@ -47,16 +56,13 @@ impl<'a> MultiColorSolidRandom<'a> {
         animations::reset_data(self.data);
     }
 
-    pub(crate) fn update(&mut self, settings: &Settings) {
+    pub(crate) fn update(&mut self) {
         for i in 0..NUM_LEDS {
-            self.data.borrow_mut()[i] = animations::create_color_with_brightness(
-                self.rendered_data[i],
-                self.brightness(settings),
-            );
+            self.data.borrow_mut()[i] = self.rendered_data[i];
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.2
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.2) as u8
     }
 }

--- a/common/src/animations/uni_color_fade_in.rs
+++ b/common/src/animations/uni_color_fade_in.rs
@@ -2,7 +2,7 @@ use crate::animations;
 use crate::animations::{COLORS, LedData, NUM_LEDS, Settings};
 use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
-use smart_leds::RGB8;
+use smart_leds::{RGB8, gamma};
 use smart_leds_trait::SmartLedsWrite;
 
 const STEP: u8 = 23;
@@ -22,11 +22,23 @@ impl<'a> UniColorFadeIn<'a> {
         }
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
         delay: &mut impl DelayNs, settings: &Settings,
-    ) {
-        ws2812.write(self.data.borrow().iter().copied()).unwrap();
+    ) where
+        E: SpiError,
+    {
+        let brightness: u8 = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+
+        ws2812
+            .write(smart_leds::brightness(
+                gamma(self.data.borrow().iter().copied()),
+                brightness,
+            ))
+            .unwrap();
+
         delay.delay_ms(settings.delay()).await;
     }
 
@@ -39,13 +51,10 @@ impl<'a> UniColorFadeIn<'a> {
     pub(crate) fn update(&mut self, settings: &Settings) {
         animations::reset_data(self.data);
 
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color =
-            animations::create_color_with_brightness(COLORS[settings.color_index()], brightness);
         for i in 0..NUM_LEDS {
-            self.data.borrow_mut()[i] = color;
+            self.data.borrow_mut()[i] = COLORS[settings.color_index()];
         }
+
         if self.ascending {
             self.current_step += 1;
             if self.current_step >= STEP {
@@ -59,7 +68,7 @@ impl<'a> UniColorFadeIn<'a> {
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 }

--- a/common/src/animations/uni_color_heartbeat.rs
+++ b/common/src/animations/uni_color_heartbeat.rs
@@ -2,7 +2,7 @@ use crate::animations;
 use crate::animations::{COLORS, LedData, NUM_LEDS, Settings};
 use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
-use smart_leds::RGB8;
+use smart_leds::{RGB8, gamma};
 use smart_leds_trait::SmartLedsWrite;
 
 const STEP: u8 = 10;
@@ -22,11 +22,23 @@ impl<'a> UniColorHeartbeat<'a> {
         }
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
         delay: &mut impl DelayNs, settings: &Settings,
-    ) {
-        ws2812.write(self.data.borrow().iter().copied()).unwrap();
+    ) where
+        E: SpiError,
+    {
+        let brightness = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+
+        ws2812
+            .write(smart_leds::brightness(
+                gamma(self.data.borrow().iter().copied()),
+                brightness,
+            ))
+            .unwrap();
+
         match self.sequence {
             3 => delay.delay_ms(settings.delay() * 30).await,
             _ => delay.delay_ms(settings.delay()).await,
@@ -40,12 +52,8 @@ impl<'a> UniColorHeartbeat<'a> {
     }
 
     pub(crate) fn update(&mut self, settings: &Settings) {
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color =
-            animations::create_color_with_brightness(COLORS[settings.color_index()], brightness);
         for i in 0..NUM_LEDS {
-            self.data.borrow_mut()[i] = color;
+            self.data.borrow_mut()[i] = COLORS[settings.color_index()];
         }
 
         match self.sequence {
@@ -77,7 +85,7 @@ impl<'a> UniColorHeartbeat<'a> {
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 }

--- a/common/src/animations/uni_color_sparkle.rs
+++ b/common/src/animations/uni_color_sparkle.rs
@@ -1,5 +1,7 @@
 use crate::animations;
-use crate::animations::{COLORS, LedData, NUM_LEDS, SHORTEST_DELAY, Settings};
+use crate::animations::{
+    COLORS, LedData, NUM_LEDS, SHORTEST_DELAY, Settings, brightness_correct, gamma_correct,
+};
 use core::cmp;
 use embedded_hal::spi::Error as SpiError;
 use embedded_hal_async::delay::DelayNs;
@@ -21,15 +23,21 @@ impl<'a> UniColorSparkle<'a> {
         }
     }
 
-    pub(crate) async fn render(
-        &mut self, ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = impl SpiError>,
+    pub(crate) async fn render<E>(
+        &mut self,
+        ws2812: &mut impl SmartLedsWrite<Color = RGB8, Error = ws2812_spi::prerendered::Error<E>>,
         delay: &mut impl DelayNs, settings: &Settings,
-    ) {
+    ) where
+        E: SpiError,
+    {
         let random_delay = self
             .prng
             .random_range(SHORTEST_DELAY..cmp::max(settings.delay(), SHORTEST_DELAY + 1));
 
+        // We're not using the smart_leds::brightness and smart_leds::gamma functions here because
+        // not all LEDs have the same brightness.
         ws2812.write(self.data.borrow().iter().copied()).unwrap();
+
         delay.delay_ms(random_delay).await;
     }
 
@@ -45,15 +53,13 @@ impl<'a> UniColorSparkle<'a> {
         for _ in 0..sparkle_amount {
             let index = self.prng.random_range(0..NUM_LEDS);
             // Random brightness between 0% and the set brightness
-            let brightness = self.prng.random_range(0.0..=self.brightness(settings));
-            self.data.borrow_mut()[index] = animations::create_color_with_brightness(
-                COLORS[settings.color_index()],
-                brightness,
-            );
+            let brightness = self.prng.random_range(0..=self.brightness(settings));
+            self.data.borrow_mut()[index] =
+                brightness_correct(gamma_correct(COLORS[settings.color_index()]), brightness);
         }
     }
 
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 }

--- a/microbit_v2/src/animations/carrousel.rs
+++ b/microbit_v2/src/animations/carrousel.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, Carrousel};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_COLORS, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{
+    LedData, NUM_COLORS, NUM_LEDS, Settings, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -24,14 +26,14 @@ impl<'a> Carrousel<'a> {
 }
 
 impl Animation for Carrousel<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
-        self.data.borrow_mut()[self.position] = animations::create_color_with_brightness(
+        self.data.borrow_mut()[self.position] = brightness_correct(
             animations::COLORS[self.color_index],
             self.brightness(settings),
         );

--- a/microbit_v2/src/animations/double_carrousel.rs
+++ b/microbit_v2/src/animations/double_carrousel.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, DoubleCarrousel};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_COLORS, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{
+    LedData, NUM_COLORS, NUM_LEDS, Settings, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -29,18 +31,18 @@ impl<'a> DoubleCarrousel<'a> {
 }
 
 impl Animation for DoubleCarrousel<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
-        self.data.borrow_mut()[self.position_1] = animations::create_color_with_brightness(
+        self.data.borrow_mut()[self.position_1] = brightness_correct(
             animations::COLORS[self.color_index_1],
             self.brightness(settings),
         );
-        self.data.borrow_mut()[self.position_2] = animations::create_color_with_brightness(
+        self.data.borrow_mut()[self.position_2] = brightness_correct(
             animations::COLORS[self.color_index_2],
             self.brightness(settings),
         );

--- a/microbit_v2/src/animations/forward_wave.rs
+++ b/microbit_v2/src/animations/forward_wave.rs
@@ -1,6 +1,6 @@
 use crate::animations::{Animation, ForwardWave};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{COLORS, LedData, NUM_LEDS, Settings, brightness_correct};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -20,11 +20,11 @@ impl<'a> ForwardWave<'a> {
         }
     }
 
-    fn get_wave(&self, settings: &Settings) -> [f32; WAVE_LENGTH] {
-        let mut wave = [0.0; WAVE_LENGTH];
+    fn get_wave(&self, settings: &Settings) -> [u8; WAVE_LENGTH] {
+        let mut wave = [0; WAVE_LENGTH];
 
         wave[0..WAVE_SECTION_LENGTH].iter_mut().for_each(|item| {
-            *item = self.brightness(settings) / 10.0;
+            *item = self.brightness(settings) / 10;
         });
         wave[WAVE_SECTION_LENGTH..(2 * WAVE_SECTION_LENGTH)]
             .iter_mut()
@@ -34,17 +34,17 @@ impl<'a> ForwardWave<'a> {
         wave[(2 * WAVE_SECTION_LENGTH)..(3 * WAVE_SECTION_LENGTH)]
             .iter_mut()
             .for_each(|item| {
-                *item = self.brightness(settings) / 4.0;
+                *item = self.brightness(settings) / 4;
             });
         wave[(3 * WAVE_SECTION_LENGTH)..(4 * WAVE_SECTION_LENGTH)]
             .iter_mut()
             .for_each(|item| {
-                *item = self.brightness(settings) / 6.0;
+                *item = self.brightness(settings) / 6;
             });
         wave[(4 * WAVE_SECTION_LENGTH)..WAVE_LENGTH]
             .iter_mut()
             .for_each(|item| {
-                *item = self.brightness(settings) / 10.0;
+                *item = self.brightness(settings) / 10;
             });
 
         wave
@@ -52,7 +52,7 @@ impl<'a> ForwardWave<'a> {
 }
 
 impl Animation for ForwardWave<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 
@@ -68,20 +68,14 @@ impl Animation for ForwardWave<'_> {
             if self.wrapped {
                 if led_index < 0 {
                     self.data.borrow_mut()[(NUM_LEDS as isize + led_index) as usize] =
-                        animations::create_color_with_brightness(
-                            COLORS[settings.color_index()],
-                            *item,
-                        );
+                        brightness_correct(COLORS[settings.color_index()], *item);
                 } else {
                     self.data.borrow_mut()[led_index as usize] =
-                        animations::create_color_with_brightness(
-                            COLORS[settings.color_index()],
-                            *item,
-                        );
+                        brightness_correct(COLORS[settings.color_index()], *item);
                 }
             } else if led_index >= 0 {
                 self.data.borrow_mut()[led_index as usize] =
-                    animations::create_color_with_brightness(COLORS[settings.color_index()], *item);
+                    brightness_correct(COLORS[settings.color_index()], *item);
             }
         }
 

--- a/microbit_v2/src/animations/mod.rs
+++ b/microbit_v2/src/animations/mod.rs
@@ -22,7 +22,7 @@ pub(crate) mod uni_color_solid;
 pub(crate) mod uni_color_sparkle;
 
 pub(crate) trait Animation {
-    fn brightness(&self, settings: &Settings) -> f32;
+    fn brightness(&self, settings: &Settings) -> u8;
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<microbit::pac::TIMER0>,

--- a/microbit_v2/src/animations/multi_color_fade_in.rs
+++ b/microbit_v2/src/animations/multi_color_fade_in.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, MultiColorFadeIn};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, NUM_COLORS, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{
+    COLORS, LedData, NUM_COLORS, NUM_LEDS, Settings, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -26,16 +28,16 @@ impl<'a> MultiColorFadeIn<'a> {
 }
 
 impl Animation for MultiColorFadeIn<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color = animations::create_color_with_brightness(COLORS[self.color_index], brightness);
+        let brightness = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+        let color = brightness_correct(COLORS[self.color_index], brightness);
         for i in 0..NUM_LEDS {
             self.data.borrow_mut()[i] = color;
         }

--- a/microbit_v2/src/animations/multi_color_heartbeat.rs
+++ b/microbit_v2/src/animations/multi_color_heartbeat.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, MultiColorHeartbeat};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, NUM_COLORS, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{
+    COLORS, LedData, NUM_COLORS, NUM_LEDS, Settings, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -26,16 +28,16 @@ impl<'a> MultiColorHeartbeat<'a> {
 }
 
 impl Animation for MultiColorHeartbeat<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color = animations::create_color_with_brightness(COLORS[self.color_index], brightness);
+        let brightness = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+        let color = brightness_correct(COLORS[self.color_index], brightness);
         for i in 0..NUM_LEDS {
             self.data.borrow_mut()[i] = color;
         }

--- a/microbit_v2/src/animations/multi_color_solid.rs
+++ b/microbit_v2/src/animations/multi_color_solid.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, MultiColorSolid};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_COLORS, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{
+    LedData, NUM_COLORS, NUM_LEDS, Settings, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -17,8 +19,8 @@ impl<'a> MultiColorSolid<'a> {
 }
 
 impl Animation for MultiColorSolid<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
@@ -30,7 +32,7 @@ impl Animation for MultiColorSolid<'_> {
             if i % LEDS_PER_COLOR == 0 {
                 color_index += 1;
             }
-            self.data.borrow_mut()[i] = animations::create_color_with_brightness(
+            self.data.borrow_mut()[i] = brightness_correct(
                 animations::COLORS[color_index % NUM_COLORS],
                 self.brightness(settings),
             );

--- a/microbit_v2/src/animations/multi_color_solid_random.rs
+++ b/microbit_v2/src/animations/multi_color_solid_random.rs
@@ -1,6 +1,6 @@
 use crate::animations::{Animation, MultiColorSolidRandom};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{LedData, NUM_LEDS, Settings, brightness_correct};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -33,18 +33,16 @@ impl<'a> MultiColorSolidRandom<'a> {
 }
 
 impl Animation for MultiColorSolidRandom<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.2
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.2) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
         for i in 0..NUM_LEDS {
-            self.data.borrow_mut()[i] = animations::create_color_with_brightness(
-                self.rendered_data[i],
-                self.brightness(settings),
-            );
+            self.data.borrow_mut()[i] =
+                brightness_correct(self.rendered_data[i], self.brightness(settings));
         }
 
         ws2812.write(self.data.borrow().iter().copied()).unwrap();

--- a/microbit_v2/src/animations/multi_color_sparkle.rs
+++ b/microbit_v2/src/animations/multi_color_sparkle.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, MultiColorSparkle};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_LEDS, SHORTEST_DELAY, Settings};
+use cookie_monster_common::animations::{
+    LedData, NUM_LEDS, SHORTEST_DELAY, Settings, brightness_correct,
+};
 use core::cmp;
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
@@ -22,7 +24,7 @@ impl<'a> MultiColorSparkle<'a> {
 }
 
 impl Animation for MultiColorSparkle<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 
@@ -36,14 +38,13 @@ impl Animation for MultiColorSparkle<'_> {
         for _ in 0..sparkle_amount {
             let index = self.prng.random_range(0..NUM_LEDS);
             // Random brightness between 0% and the set brightness
-            let brightness = self.prng.random_range(0.0..=self.brightness(settings));
+            let brightness = self.prng.random_range(0..=self.brightness(settings));
             let random_color = RGB8::new(
                 self.prng.random_range(0..255),
                 self.prng.random_range(0..255),
                 self.prng.random_range(0..255),
             );
-            self.data.borrow_mut()[index] =
-                animations::create_color_with_brightness(random_color, brightness);
+            self.data.borrow_mut()[index] = brightness_correct(random_color, brightness);
         }
 
         let random_delay = self

--- a/microbit_v2/src/animations/multi_color_strand.rs
+++ b/microbit_v2/src/animations/multi_color_strand.rs
@@ -1,6 +1,6 @@
 use crate::animations::{Animation, MultiColorStrand, NUM_STRANDS, Strand};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{LedData, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{LedData, NUM_LEDS, Settings, brightness_correct};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -47,7 +47,7 @@ impl<'a> MultiColorStrand<'a> {
 }
 
 impl Animation for MultiColorStrand<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 
@@ -61,10 +61,7 @@ impl Animation for MultiColorStrand<'_> {
         for strand in &mut self.strands {
             update_strand(strand);
             self.data.borrow_mut()[strand.position as usize] =
-                animations::create_color_with_brightness(
-                    COLORS[strand.color_index as usize],
-                    brightness,
-                );
+                brightness_correct(COLORS[strand.color_index as usize], brightness);
         }
 
         ws2812.write(self.data.borrow().iter().copied()).unwrap();

--- a/microbit_v2/src/animations/uni_color_front_to_back_wave.rs
+++ b/microbit_v2/src/animations/uni_color_front_to_back_wave.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, UniColorFrontToBackWave};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, Settings, VERTICAL_SLICES};
+use cookie_monster_common::animations::{
+    COLORS, LedData, Settings, VERTICAL_SLICES, brightness_correct,
+};
 use embedded_hal::delay::DelayNs;
 use microbit::pac::{SPI0, TIMER0};
 use nrf52833_hal::Timer;
@@ -15,7 +17,7 @@ impl<'a> UniColorFrontToBackWave<'a> {
 }
 
 impl Animation for UniColorFrontToBackWave<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 
@@ -28,10 +30,8 @@ impl Animation for UniColorFrontToBackWave<'_> {
 
         for led in &slice {
             led.map(|l| {
-                self.data.borrow_mut()[l as usize] = animations::create_color_with_brightness(
-                    COLORS[settings.color_index()],
-                    self.brightness(settings),
-                );
+                self.data.borrow_mut()[l as usize] =
+                    brightness_correct(COLORS[settings.color_index()], self.brightness(settings));
             });
         }
 

--- a/microbit_v2/src/animations/uni_color_heartbeat.rs
+++ b/microbit_v2/src/animations/uni_color_heartbeat.rs
@@ -1,6 +1,6 @@
 use crate::animations::{Animation, UniColorHeartbeat};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, NUM_LEDS, Settings};
+use cookie_monster_common::animations::{COLORS, LedData, NUM_LEDS, Settings, brightness_correct};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -21,17 +21,16 @@ impl<'a> UniColorHeartbeat<'a> {
 }
 
 impl Animation for UniColorHeartbeat<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
-        let brightness =
-            (self.brightness(settings) / f32::from(STEP)) * f32::from(self.current_step);
-        let color =
-            animations::create_color_with_brightness(COLORS[settings.color_index()], brightness);
+        let brightness = (f32::from(self.brightness(settings)) * f32::from(self.current_step)
+            / f32::from(STEP)) as u8;
+        let color = brightness_correct(COLORS[settings.color_index()], brightness);
         for i in 0..NUM_LEDS {
             self.data.borrow_mut()[i] = color;
         }

--- a/microbit_v2/src/animations/uni_color_solid.rs
+++ b/microbit_v2/src/animations/uni_color_solid.rs
@@ -1,6 +1,6 @@
 use crate::animations::{Animation, UniColorSolid};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, Settings};
+use cookie_monster_common::animations::{COLORS, LedData, Settings, brightness_correct};
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
 use microbit::hal::spi::Spi;
@@ -15,18 +15,15 @@ impl<'a> UniColorSolid<'a> {
 }
 
 impl Animation for UniColorSolid<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
-        settings.brightness() * 0.05
+    fn brightness(&self, settings: &Settings) -> u8 {
+        (f32::from(settings.brightness()) * 0.05) as u8
     }
 
     fn render(
         &mut self, ws2812: &mut Ws2812<Spi<SPI0>>, timer: &mut Timer<TIMER0>, settings: &Settings,
     ) {
         self.data.borrow_mut().iter_mut().for_each(|e| {
-            *e = animations::create_color_with_brightness(
-                COLORS[settings.color_index()],
-                self.brightness(settings),
-            );
+            *e = brightness_correct(COLORS[settings.color_index()], self.brightness(settings));
         });
 
         ws2812.write(self.data.borrow().iter().copied()).unwrap();

--- a/microbit_v2/src/animations/uni_color_sparkle.rs
+++ b/microbit_v2/src/animations/uni_color_sparkle.rs
@@ -1,6 +1,8 @@
 use crate::animations::{Animation, UniColorSparkle};
 use cookie_monster_common::animations;
-use cookie_monster_common::animations::{COLORS, LedData, NUM_LEDS, SHORTEST_DELAY, Settings};
+use cookie_monster_common::animations::{
+    COLORS, LedData, NUM_LEDS, SHORTEST_DELAY, Settings, brightness_correct,
+};
 use core::cmp;
 use embedded_hal::delay::DelayNs;
 use microbit::hal::Timer;
@@ -21,7 +23,7 @@ impl<'a> UniColorSparkle<'a> {
 }
 
 impl Animation for UniColorSparkle<'_> {
-    fn brightness(&self, settings: &Settings) -> f32 {
+    fn brightness(&self, settings: &Settings) -> u8 {
         settings.brightness()
     }
 
@@ -35,11 +37,9 @@ impl Animation for UniColorSparkle<'_> {
         for _ in 0..sparkle_amount {
             let index = self.prng.random_range(0..NUM_LEDS);
             // Random brightness between 0% and the set brightness
-            let brightness = self.prng.random_range(0.0..=self.brightness(settings));
-            self.data.borrow_mut()[index] = animations::create_color_with_brightness(
-                COLORS[settings.color_index()],
-                brightness,
-            );
+            let brightness = self.prng.random_range(0..=self.brightness(settings));
+            self.data.borrow_mut()[index] =
+                brightness_correct(COLORS[settings.color_index()], brightness);
         }
 
         let random_delay = self

--- a/quinled_dig_quad/Cargo.toml
+++ b/quinled_dig_quad/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 cookie-monster-common = { workspace = true }
 defmt = { workspace = true }
-embassy-executor = { version = "0.7.0", features = ["defmt", "task-arena-size-49152"] }
+embassy-executor = { version = "0.7.0", features = ["defmt", "task-arena-size-65536"] }
 embassy-sync = "0.7.0"
 embassy-time = { version = "0.4.0", features = ["generic-queue-8"] }
 embedded-hal-async = { workspace = true }


### PR DESCRIPTION
I've been trying to tweak the SPI to speed up the LED data write, but I couldn't get it lower than 49ms. Which is much higher then the theoretical transfer time at 3.8 Mhz.

Switching to the prerendered module provided by ws2812-spi reduced the write to about 26ms. This seems still a bit high, but that's good enough for the moment.

I also tried to configure the SPI with DMA with different buffer sizes, but it only made things worst.